### PR TITLE
hint to drill filament path on Anthead added

### DIFF
--- a/docs/hardware/guides/toolheads/1_anthead/data.yml
+++ b/docs/hardware/guides/toolheads/1_anthead/data.yml
@@ -150,7 +150,7 @@ steps:
     focus:
       - "LED Carrier Jig"
 
-  - description: "Install 7 heat inserts into the Main Body."
+  - description: "Install 7 heat inserts into the Main Body. Drill out the filament path in the middle with a 4 mm drill for the PTFE tube."
     camera:
       azimuth: 214
       polar: 47
@@ -203,7 +203,7 @@ steps:
     focus: 
       - "Duct Heat Inserts"
 
-  - description: "Install 4 heat inserts into the Hotend Mount."
+  - description: "Install 4 heat inserts into the Hotend Mount. Drill out the filament path with a 4 mm drill for the PTFE tube."
     camera:
       azimuth: 124
       polar: 97


### PR DESCRIPTION
The current version of the Anthead does not have a 4mm filament path on the hotend mount and the main body for the PTFE tube to go through, because they added their filament cutter. The manual of Anthead says, you should drill these two holes out, so the PTFE tube can go in there, if you don't use the filament cutter. Since this is kind of important, I suggest adding this to the manual. Maybe there should even be a highlight on the hole in the CAD? I don't know yet how to do that though. So here is a text addition first.